### PR TITLE
nbtheory-impl: avoid integer overflow

### DIFF
--- a/src/core/include/math/nbtheory-impl.h
+++ b/src/core/include/math/nbtheory-impl.h
@@ -490,8 +490,10 @@ template <typename IntVector>
 IntVector PolynomialPower(const IntVector& input, usint power) {
     usint finalDegree = (input.GetLength() - 1) * power;
     IntVector finalPoly(finalDegree + 1, input.GetModulus());
-    for (usint i = 0; i < input.GetLength(); ++i)
-        finalPoly[i * power] = input[i];
+    for (usint i = 0; i < input.GetLength(); ++i) {
+        size_t index = static_cast<size_t>(i) * static_cast<size_t>(power);
+        finalPoly[index] = input[i];
+    }
     return finalPoly;
 }
 


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @eelenberg and @jweese. The 32-bit values `i` and `power` are being multiplied, and their product could overflow 32 bits before the result is promoted to `size_t` in order to index `finalPoly`. To avoid the potential overflow, cast both operants to `size_t`.

on-behalf-of: @permanence-ai github-ai@permanence.ai