### PR TITLE
ckkspackedencoding: avoid integer overflow

### DIFF
--- a/src/pke/lib/encoding/ckkspackedencoding.cpp
+++ b/src/pke/lib/encoding/ckkspackedencoding.cpp
@@ -602,11 +602,12 @@ void CKKSPackedEncoding::FitToNativeVector(const std::vector<int64_t>& vec, int6
     uint32_t gap       = ringDim / dslots;
     for (usint i = 0; i < vec.size(); i++) {
         NativeInteger n(vec[i]);
+        size_t index = static_cast<size_t>(gap) * static_cast<size_t>(i); 
         if (n > bigValueHf) {
-            (*nativeVec)[gap * i] = n.ModSub(diff, modulus);
+            (*nativeVec)[index] = n.ModSub(diff, modulus);
         }
         else {
-            (*nativeVec)[gap * i] = n.Mod(modulus);
+            (*nativeVec)[index] = n.Mod(modulus);
         }
     }
 }


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese. The 32-bit values `gap` and `i` are being multiplied and the product could overflow 32 bits before being promoted to `size_t` in order to index `*nativeVec`. To avoid the overflow, both operands are cast to `size_t` before the multiplication.

on-behalf-of: @permanence-ai github-ai@permanence.ai