### PR TITLE
discrete gaussian: avoid float overflow

### DIFF
--- a/src/core/lib/math/discretegaussiangeneratorgeneric.cpp
+++ b/src/core/lib/math/discretegaussiangeneratorgeneric.cpp
@@ -212,7 +212,7 @@ int64_t BaseSampler::GenerateIntegerKnuthYao() {
 
 void BaseSampler::Initialize(double mean) {
     m_vals.clear();
-    double variance = b_std * b_std;
+    double variance = static_cast<double>(b_std) * static_cast<double>(b_std);
 
     // this value of fin (M) corresponds to the limit for double precision
     // usually the bound of m_std * M is used, whe re M = 20 .. 40 - see DG14 for


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @eelenberg and @jweese. Here, `b_std` is being squared, and the product could overflow its type `float` before it is assigned to the `double` `variance`. To prevent the overflow, `b_std` is cast to `double` before performing the multiplication.

on-behalf-of: @permanence-ai github-ai@permanence.ai