### PR TITLE
keyswitch-bv: avoid integer overflow

### DIFF
--- a/src/pke/lib/keyswitch/keyswitch-bv.cpp
+++ b/src/pke/lib/keyswitch/keyswitch-bv.cpp
@@ -230,8 +230,9 @@ EvalKey<DCRTPoly> KeySwitchBV::KeySwitchGenInternal(const PrivateKey<DCRTPoly> o
     auto elementParams    = newp0.GetParams();
 
     if (digitSize > 0) {
-        av.reserve(sOld.GetNumOfElements() * digitSize);
-        bv.reserve(sOld.GetNumOfElements() * digitSize);
+        const auto reserveSize = static_cast<size_t>(sOld.GetNumOfElements()) * static_cast<size_t>(digitSize);
+        av.reserve(reserveSize);
+        bv.reserve(reserveSize);
         for (usint i = 0; i < sOld.GetNumOfElements(); i++) {
             for (auto&& sOldDecomposed : sOld.GetElementAtIndex(i).PowersOfBase(digitSize)) {
                 DCRTPoly filtered(elementParams, Format::EVALUATION, true);


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese. The 32-bit values
`sOld.GetNumOfElements()` and `digitSize` are being multiplied, and the product could overflow 32 bits before the result is promoted to `size_t` in the calls to `reserve`. To avoid the overflow, cast each operand to `size_t` before the multiplication.

on-behalf-of: @permanence-ai github-ai@permanence.ai