### PR TITLE
keyswitch-hybrid: avoid integer overflow in multiplication

### DIFF
--- a/src/pke/lib/keyswitch/keyswitch-hybrid.cpp
+++ b/src/pke/lib/keyswitch/keyswitch-hybrid.cpp
@@ -352,7 +352,7 @@ std::shared_ptr<std::vector<DCRTPoly>> KeySwitchHYBRID::EvalKeySwitchPrecomputeC
         if (part == numPartQl - 1) {
             auto paramsPartQ = cryptoParams->GetParamsPartQ(part);
 
-            uint32_t sizePartQl = sizeQl - alpha * part;
+            const auto sizePartQl = sizeQl - static_cast<size_t>(alpha) * static_cast<size_t>(part);
 
             std::vector<NativeInteger> moduli(sizePartQl);
             std::vector<NativeInteger> roots(sizePartQl);


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @eelenberg and @jweese. The 32-bit values `alpha` and `part` are being multiplied, and their product could overflow 32 bits before the result is promoted to a `size_t` to compute `sizePartQl`. To avoid the potential overflow, both operands are cast to `size_t`.

The use of `auto` for `sizePartQl` changes its type (from explicit `uint32_t` to deduced `size_t`), but this is safe since its lifetime ends at the end of the `if` block, and it is only used as the initial size of two vectors.

on-behalf-of: @permanence-ai github-ai@permanence.ai