### PR TITLE
ckksrns-fhe: avoid integer overflow in multiplication

### DIFF
--- a/src/pke/lib/scheme/ckksrns/ckksrns-fhe.cpp
+++ b/src/pke/lib/scheme/ckksrns/ckksrns-fhe.cpp
@@ -1605,10 +1605,11 @@ Ciphertext<DCRTPoly> FHECKKSRNS::EvalLinearTransform(const std::vector<ConstPlai
     DCRTPoly first;
 
     for (uint32_t j = 0; j < gStep; j++) {
-        Ciphertext<DCRTPoly> inner = EvalMultExt(cc->KeySwitchExt(ct, true), A[bStep * j]);
+        const auto index = static_cast<size_t>(bStep) * static_cast<size_t>(j);
+        Ciphertext<DCRTPoly> inner = EvalMultExt(cc->KeySwitchExt(ct, true), A[index]);
         for (uint32_t i = 1; i < bStep; i++) {
-            if (bStep * j + i < slots) {
-                EvalAddExtInPlace(inner, EvalMultExt(fastRotation[i - 1], A[bStep * j + i]));
+            if (index + i < slots) {
+                EvalAddExtInPlace(inner, EvalMultExt(fastRotation[i - 1], A[index + i]));
             }
         }
 
@@ -1622,7 +1623,7 @@ Ciphertext<DCRTPoly> FHECKKSRNS::EvalLinearTransform(const std::vector<ConstPlai
         else {
             inner = cc->KeySwitchDown(inner);
             // Find the automorphism index that corresponds to rotation index index.
-            usint autoIndex = FindAutomorphismIndex2nComplex(bStep * j, M);
+            usint autoIndex = FindAutomorphismIndex2nComplex(index, M);
             std::vector<usint> map(N);
             PrecomputeAutoMap(N, autoIndex, &map);
             DCRTPoly firstCurrent = inner->GetElements()[0].AutomorphismTransform(autoIndex, map);
@@ -2542,11 +2543,12 @@ void FHECKKSRNS::FitToNativeVector(uint32_t ringDim, const std::vector<int64_t>&
     uint32_t gap       = ringDim / dslots;
     for (usint i = 0; i < vec.size(); i++) {
         NativeInteger n(vec[i]);
+        const auto index = static_cast<size_t>(gap) * static_cast<size_t>(i);
         if (n > bigValueHf) {
-            (*nativeVec)[gap * i] = n.ModSub(diff, modulus);
+            (*nativeVec)[index] = n.ModSub(diff, modulus);
         }
         else {
-            (*nativeVec)[gap * i] = n.Mod(modulus);
+            (*nativeVec)[index] = n.Mod(modulus);
         }
     }
 }


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese. The 32-bit values `bStep` and `j` are being multiplied, and their product could overflow 32 bits before the result is promoted to a `size_t` to index into `A`. To avoid the potential overflow, both operands are cast to `size_t`. Similarly, `gap` and `i` are being multiplied, and their product could overflow 32 bits before the result is promoted to a `size_t` to index into `nativeVec`. To avoid the potential overflow, both operands are cast to `size_t`.

on-behalf-of: @permanence-ai github-ai@permanence.ai